### PR TITLE
Clipboard shenannigans

### DIFF
--- a/snippy
+++ b/snippy
@@ -400,6 +400,9 @@ run() {
 
         move_cursor "Left" $cursor_position
 
+        # We need a little pause to handle the time to have the content of tmpfile pasted if is_gui
+        sleep "$focus_wait"
+
         # Restore current clipboard
         echo -ne "$current_clipboard" | xsel --clipboard --input
     fi

--- a/snippy
+++ b/snippy
@@ -392,7 +392,7 @@ run() {
             xdotool key ctrl+v sleep "$focus_wait"
             move_cursor "Up" $cursor_line_position
         else
-            xdotool key ctrl+shift+v
+            xdotool key ctrl+shift+v sleep "$focus_wait"
             if is_vim; then
                 move_cursor "Up" $cursor_line_position
             fi


### PR DESCRIPTION
Introduced a little pause to allow sufficient time between tmpfile being pasted if is_gui and the previous clipboard being restored.
Previously, without the little pause, it resulted in having your previous clipboard pasted 99% of the time instead of the contents of tmpfile