### PR TITLE
Adding mangowm support

### DIFF
--- a/snippy
+++ b/snippy
@@ -135,6 +135,9 @@ get_focused_window_class() {
     hyprland)
       hyprctl activewindow -j | jq -r '.class | ascii_downcase'
       ;;
+    mango)
+      mmsg get focusing-client | jq -r '.appid | ascii_downcase'
+      ;;
     esac
   else
     xdotool getwindowfocus getwindowclassname | tr '[:upper:]' '[:lower:]'
@@ -152,6 +155,9 @@ get_focused_window_name() {
       ;;
     hyprland)
       hyprctl activewindow -j | jq -r '.title'
+      ;;
+    mango)
+      mmsg get focusing-client | jq -r '.title | ascii_downcase'
       ;;
     esac
   else


### PR DESCRIPTION
Hello!

This is a pull request to add window class / title support for mangowm. Currently if we use snippy on any terminal inside a mango session, it does not paste with CTRL+SHIFT+V, because the script is unable to fetch the window class / title. 

This PR uses the mango IPC to fetch the window class / title, and fixes the paste issue. 

Source: https://mangowm.github.io/docs/ipc

Kind Regards,
AJ